### PR TITLE
cleanup metric names

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -154,7 +154,7 @@ def read_callback():
     return
 
   for key,value in info.items():
-    key_prefix = ''
+    key_prefix = None
     key_root = key
     if not value in METRIC_TYPES:
       try:
@@ -165,7 +165,10 @@ def read_callback():
       continue
 
     key_root, val_type = METRIC_TYPES[key_root]
-    key_name = METRIC_DELIM.join([key_prefix, key_root])
+    if key_prefix:
+      key_name = METRIC_DELIM.join([key_prefix, key_root])
+    else:
+      key_name = key_root
     val = collectd.Values(plugin=NAME, type=val_type)
     val.type_instance = key_name
     val.values = [ value ]


### PR DESCRIPTION
this fixes an issue where the metrics not associated with frontend or backend get weird names
in graphite for instance: gauge-_tasks now is named gauge-tasks

(playing with github, sorry if annoying)
